### PR TITLE
Add manage-repo-subscription tool to handle repository notification settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An MCP (Model Context Protocol) server that provides tools for managing GitHub n
 - Subscribe or unsubscribe from notification threads
 - Mark threads as done
 - Manage repository-specific notifications
+- Control repository notification settings (all activity, default, or mute)
 
 ## Prerequisites
 
@@ -79,6 +80,7 @@ Add the server to your `claude_desktop_config.json` file:
 | `delete-thread-subscription` | Unsubscribe from a thread |
 | `list-repo-notifications` | List notifications for a specific repository |
 | `mark-repo-notifications-read` | Mark notifications for a repository as read |
+| `manage-repo-subscription` | Manage repository subscriptions: all_activity, default (participating and @mentions), or ignore (mute) |
 
 ## Example Prompts
 
@@ -91,6 +93,10 @@ Here are some example prompts you can use with Claude Desktop once the server is
 - "Unsubscribe me from thread 12345."
 - "What notifications do I have for the octocat/Hello-World repository?"
 - "Mark all notifications from the octocat/Hello-World repository as read."
+- "Watch all activity on the octocat/Hello-World repository."
+- "Set the octocat/Hello-World repository to default settings (participating and @mentions)."
+- "Check my notification settings for the octocat/Hello-World repository."
+- "Mute all notifications from the octocat/Hello-World repository."
 
 ## Development
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { registerSetThreadSubscriptionTool } from "./tools/set-thread-subscripti
 import { registerDeleteThreadSubscriptionTool } from "./tools/delete-thread-subscription.js";
 import { registerListRepoNotificationsTool } from "./tools/list-repo-notifications.js";
 import { registerMarkRepoNotificationsReadTool } from "./tools/mark-repo-notifications-read.js";
+import { registerManageRepoSubscriptionTool } from "./tools/manage-repo-subscription.js";
 
 /**
  * Initialize and start the MCP server
@@ -30,9 +31,9 @@ export async function startServer() {
         tools: {}
       }
     });
-    
+
     console.error("Initializing GitHub Notifications MCP Server...");
-    
+
     // Register all tools
     registerListNotificationsTool(server);
     registerMarkNotificationsReadTool(server);
@@ -44,13 +45,14 @@ export async function startServer() {
     registerDeleteThreadSubscriptionTool(server);
     registerListRepoNotificationsTool(server);
     registerMarkRepoNotificationsReadTool(server);
-    
+    registerManageRepoSubscriptionTool(server);
+
     console.error("All tools registered successfully.");
-    
+
     // Connect using stdio transport
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    
+
     console.error("GitHub Notifications MCP Server running on stdio transport.");
     console.error("Authentication: Using GITHUB_TOKEN environment variable.");
   } catch (error) {

--- a/src/tools/manage-repo-subscription.ts
+++ b/src/tools/manage-repo-subscription.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+import { githubPut, githubDelete, githubGet } from '../utils/api.js';
+import { formatError } from '../utils/formatters.js';
+
+/**
+ * Schema for manage-repo-subscription tool input parameters
+ */
+export const manageRepoSubscriptionSchema = z.object({
+    owner: z.string().min(1, 'Repository owner is required')
+        .describe('The account owner of the repository. The name is not case sensitive.'),
+    repo: z.string().min(1, 'Repository name is required')
+        .describe('The name of the repository without the .git extension. The name is not case sensitive.'),
+    action: z.enum(['all_activity', 'default', 'ignore', 'get'])
+        .describe('The action to perform: all_activity (watch all), default (participating and @mentions only), ignore (mute notifications), or get (view current settings)'),
+    options: z.object({
+        subscribed: z.boolean().optional()
+            .describe('Whether to receive notifications from this repository'),
+        ignored: z.boolean().optional()
+            .describe('Whether to ignore all notifications from this repository')
+    }).optional()
+        .describe('Optional settings for custom subscription configuration')
+});
+
+export type ManageRepoSubscriptionArgs = z.infer<typeof manageRepoSubscriptionSchema>;
+
+interface SubscriptionResponse {
+    subscribed: boolean;
+    ignored: boolean;
+    reason: string | null;
+    created_at: string;
+    url: string;
+    repository_url: string;
+}
+
+/**
+ * Tool implementation for managing repository subscriptions
+ */
+export async function manageRepoSubscriptionHandler(args: ManageRepoSubscriptionArgs) {
+    const { owner, repo, action, options } = args;
+
+    try {
+        switch (action) {
+            case 'get':
+                try {
+                    const response = await githubGet<SubscriptionResponse>(`/repos/${owner}/${repo}/subscription`);
+                    const formattedDate = new Date(response.created_at).toLocaleString();
+                    return {
+                        content: [{
+                            type: 'text',
+                            text: `Subscription status for ${owner}/${repo}:
+• API Subscription: ${response.subscribed ? 'Watching all activity' : 'Not watching'}
+• Notifications: ${response.ignored ? 'Ignored' : 'Active'}
+• Created at: ${formattedDate}
+• Web Interface: https://github.com/${owner}/${repo}`
+                        }]
+                    };
+                } catch (error: any) {
+                    // Special handling for 404 in get action - could be default or custom settings
+                    if (error.message?.includes('Resource not found')) {
+                        return {
+                            content: [{
+                                type: 'text',
+                                text: `Subscription status for ${owner}/${repo}:
+• Default settings (participating and @mentions only)
+• or Custom through the GitHub web interface at:
+  https://github.com/${owner}/${repo}`
+                            }]
+                        };
+                    }
+                    throw error; // Re-throw other errors to be handled by the outer catch
+                }
+
+            case 'all_activity':
+                await githubPut(`/repos/${owner}/${repo}/subscription`, {
+                    subscribed: true,
+                    ignored: false
+                });
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `Successfully set ${owner}/${repo} to watch all activity`
+                    }]
+                };
+
+            case 'default':
+                await githubDelete(`/repos/${owner}/${repo}/subscription`);
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `Successfully set ${owner}/${repo} to default settings (participating and @mentions only)`
+                    }]
+                };
+
+            case 'ignore':
+                await githubPut(`/repos/${owner}/${repo}/subscription`, {
+                    subscribed: false,
+                    ignored: true
+                });
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `Successfully set ${owner}/${repo} to ignore all notifications`
+                    }]
+                };
+        }
+    } catch (error: any) {
+        return {
+            isError: true,
+            content: [{
+                type: 'text',
+                text: formatError(`Failed to manage repository subscription for ${owner}/${repo}`, error)
+            }]
+        };
+    }
+}
+
+/**
+ * Register this tool with the server
+ */
+export function registerManageRepoSubscriptionTool(server: any) {
+    server.tool(
+        'manage-repo-subscription',
+        'Manage repository subscription settings including fine-grained notification preferences',
+        manageRepoSubscriptionSchema.shape,
+        manageRepoSubscriptionHandler
+    );
+} 


### PR DESCRIPTION

- Updated README.md to include new functionality for managing repository subscriptions.
- Implemented manage-repo-subscription tool in src/tools/manage-repo-subscription.ts, allowing users to set notification preferences (all_activity, default, ignore, get).

This enhances user control over GitHub notifications and improves overall functionality.